### PR TITLE
Call `res.redirect` after user's `handler` code for login callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 - [#34](https://github.com/okta/okta-oidc-middleware/pull/34) Fixes Org AS login issue
+- [#3](https://github.com/okta/okta-oidc-middleware/pull/3) Call `res.redirect()` after custom `routes.loginCallback.handler`
 
 # 4.3.0
 

--- a/src/connectUtil.js
+++ b/src/connectUtil.js
@@ -99,14 +99,21 @@ connectUtil.createLoginCallbackHandler = context => {
 
   const customHandlerArity = customHandler.length;
   return (req, res, next) => {
+    const afterCustomNextHandler = (err) => {
+      if (err) {
+        next(err);
+      } else if (!res._headerSent) {
+        res.redirect(routes.loginCallback.afterCallback || req.session.returnTo || '/');
+      }
+    };
     const nextHandler = err => {
       if (err && customHandlerArity < 4) return next(err);
       switch(customHandlerArity) {
         case 4:
-          customHandler(err, req, res, next);
+          customHandler(err, req, res, afterCustomNextHandler);
           break;
         case 3:
-          customHandler(req, res, next);
+          customHandler(req, res, afterCustomNextHandler);
           break;
         default:
           throw new OIDCMiddlewareError('middlewareError', 'Your custom callback handler must request "next"');

--- a/src/connectUtil.js
+++ b/src/connectUtil.js
@@ -102,7 +102,7 @@ connectUtil.createLoginCallbackHandler = context => {
     const afterCustomNextHandler = (err) => {
       if (err) {
         next(err);
-      } else if (!res.writableEnded) {
+      } else if (!res.headersSent) {
         res.redirect(routes.loginCallback.afterCallback || req.session.returnTo || '/');
       }
     };

--- a/src/connectUtil.js
+++ b/src/connectUtil.js
@@ -102,7 +102,7 @@ connectUtil.createLoginCallbackHandler = context => {
     const afterCustomNextHandler = (err) => {
       if (err) {
         next(err);
-      } else if (!res._headerSent) {
+      } else if (!res.writableEnded) {
         res.redirect(routes.loginCallback.afterCallback || req.session.returnTo || '/');
       }
     };


### PR DESCRIPTION
Internal ref: [OKTA-306438](https://oktainc.atlassian.net/browse/OKTA-306438)
Resolves https://github.com/okta/okta-oidc-js/issues/340
Overseedes https://github.com/okta/okta-oidc-js/pull/805

This PR improves case when user defines `routes.loginCallback.handler`
Description of this function in [readme](https://github.com/okta/okta-oidc-middleware#customizing-routes):

> A function that is called after a successful authentication callback, but before the final redirect within your application. Useful for requirements such as conditional post-authentication redirects, or sending data to logging systems.


```js
const oidc = new ExpressOIDC({
  // ...
  routes: {
    loginCallback: {
      handler: (req, res, next) => {
        // Perform custom logic before final redirect, then call next()
      },
    },
```

## Current behavior
The developer needs to manually call `res.redirect()` in `handler`.
This requirement is not explicitly covered in readme and can lead to confusion (see https://github.com/okta/okta-oidc-js/issues/340)
However, it can be useful to give developer the power to manually set redirect path after authentication.
For example, developer can use `req.userContext.userinfo.locale` 

## New behavior
If developer did not call `res.redirect()` in `handler`, it will be called automatically with correct value (`routes.loginCallback.afterCallback`) in `next()`.
Otherwise, if developer have manually called `res.redirect()` with the value he needs, `next()` will do nothing.

