### PR TITLE
Fix 401 error in login route handler when login callback path is child of login path

### DIFF
--- a/src/connectUtil.js
+++ b/src/connectUtil.js
@@ -32,8 +32,8 @@ connectUtil.createOIDCRouter = context => {
   const loginCallbackPath = routes.loginCallback.path;
   const logoutPath = routes.logout.path;
 
-  oidcRouter.use(loginPath, bodyParser.urlencoded({ extended: false}), connectUtil.createLoginHandler(context));
   oidcRouter.use(loginCallbackPath, connectUtil.createLoginCallbackHandler(context));
+  oidcRouter.use(loginPath, bodyParser.urlencoded({ extended: false}), connectUtil.createLoginHandler(context));
   oidcRouter.post(logoutPath, connectUtil.createLogoutHandler(context));
 
   oidcRouter.use((err, req, res, next) => {

--- a/test/unit/callback.spec.js
+++ b/test/unit/callback.spec.js
@@ -157,12 +157,21 @@ describe('callback', () => {
     });
   }
 
-  it('handles a callback', async () => {
-    await bootstrap();
+  it('handles a login callback', async () => {
+    await bootstrap({
+      routes: {
+        login: {
+          path: '/login'
+        },
+        loginCallback: {
+          path: '/login/callback'
+        }
+      }
+    });
     mockToken();
     return new Promise((resolve, reject) => {
       agent
-        .get('/authorization-code/callback')
+        .get('/login/callback')
         .query({ state, code: 'foo' })
         .set('Accept', 'application/json')
         .expect(302)


### PR DESCRIPTION

Resolves https://github.com/okta/okta-oidc-js/issues/207

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-middleware/blob/master/CONTRIBUTING.md#commit)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [OKTA-262240](https://oktainc.atlassian.net/browse/OKTA-262240)


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

