### PR TITLE
fix: invoking logout without credentials no longer throws error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 4.3.0
+
+### Bug Fixes
+
+- [#37](https://github.com/okta/okta-oidc-middleware/pull/37) fix: `.logout` no longer throws error without valid credentials
+
 # 4.2.0
 
 ### Bug Fixes

--- a/src/logout.js
+++ b/src/logout.js
@@ -55,6 +55,10 @@ logout.forceLogoutAndRevoke = context => {
   }
   const revokeToken = makeTokenRevoker({ issuer, client_id, client_secret, errorHandler: makeErrorHandler(emitter) });
   return async (req, res /*, next */) => {
+    if (!req.userContext) {
+      return res.sendStatus(401);
+    }
+
     const tokens = req.userContext.tokens;
     const revokeIfExists = token_hint => tokens[token_hint] ? revokeToken({token_hint, token: tokens[token_hint]}) : null;
     const revokes = REVOKABLE_TOKENS.map( revokeIfExists );

--- a/test/unit/logout.spec.js
+++ b/test/unit/logout.spec.js
@@ -73,7 +73,16 @@ describe('logout', () => {
         };
       });
     
-    
+      describe('logout without active session', () => {
+        it('returns 401', async () => {
+          res.sendStatus = jest.fn();
+          req.userContext = undefined;
+          await logout(req, res);
+          expect(fetch).not.toHaveBeenCalled();
+          expect(res.sendStatus).toHaveBeenCalledWith(401);
+        });
+      });
+
       describe('revoke tokens', () => {
         it('revokes refresh_token', async () => {
           const tokenVal = 'sometoken';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our [guidelines](/okta/okta-oidc-middleware/blob/master/CONTRIBUTING.md#commit)
- [X ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
Invoking logout without valid credentials throws error

Issue Number: 436562


## What is the new behavior?
401 is returned when logout is called without credentials

## Does this PR introduce a breaking change?
- [ ] Yes
- [X ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

