### PR TITLE
feat: adds PKCE support

### DIFF
--- a/src/ExpressOIDC.js
+++ b/src/ExpressOIDC.js
@@ -39,7 +39,8 @@ module.exports = class ExpressOIDC extends EventEmitter {
    * @param {string} options.issuer The OpenId Connect issuer
    * @param {string} options.client_id This app's OpenId Connect client id
    * @param {string} options.client_secret This app's OpenId Connect client secret
-   * @param {string} options.loginRedirectUri The location of the login authorization callback if not redirecting to this app 
+   * @param {boolean} [options.usePKCE=false] Use PKCE, client secret doesn't need to be provided if set to true
+   * @param {string} options.loginRedirectUri The location of the login authorization callback if not redirecting to this app
    * @param {string} options.logoutRedirectUri The location of the logout callback if not redirecting to this app
    * @param {string} [options.scope=openid] The scopes that will determine the claims on the tokens
    * @param {string} [options.response_type=code] The OpenId Connect response type
@@ -60,6 +61,7 @@ module.exports = class ExpressOIDC extends EventEmitter {
       issuer,
       client_id,
       client_secret,
+      usePKCE,
       appBaseUrl,
       loginRedirectUri,
       logoutRedirectUri,
@@ -73,7 +75,7 @@ module.exports = class ExpressOIDC extends EventEmitter {
     assertClientId(client_id);
 
     // Validate the client_secret param
-    assertClientSecret(client_secret);
+    !usePKCE && assertClientSecret(client_secret);
 
     // Validate the appBaseUrl param
     assertAppBaseUrl(appBaseUrl);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-middleware/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?

The middleware doesn't support PKCE, so it's always necessary to use a client secret. See also community request #27.  

Issue Number: #27

## What is the new behavior?

The middleware optionally supports PKCE by passing ```usePKCE``` flag during initialisation, eg:

```js
const oidc = new ExpressOIDC({
  issuer: 'https://{yourOktaDomain}/oauth2/default',
  client_id: '{clientId}',
  // client_secret: '{clientSecret}', # not required when using PKCE
  usePKCE: true,
  appBaseUrl: '{appBaseUrl}',
  scope: 'openid'
});
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Hi everybody I am opening this **draft** to understand if you are willing to add necessary changes to support PKCE as requested by #27.
If yes I can add related unit, integration and e2e test and as well documentation. 
I guess I might need some support from the maintainers to setup the e2e test, if you are running them on some CI environment as we should then probably have an app without client secret, with PKCE enabled and auth code flow enabled. 


## Reviewers

