### PR TITLE
fix: Fixes missing type declaration in downstream consumers

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -20,7 +20,7 @@ if (shell.exec(BANNER_CMD).code !== 0) {
   shell.exit(1);
 };
 
-shell.cp(`-Rf`, [`src`, `index.js`, `package.json`, `LICENSE`, `*.md`], `${NPM_DIR}`);
+shell.cp(`-Rf`, [`src`, `types`, `index.js`, `package.json`, `LICENSE`, `*.md`], `${NPM_DIR}`);
 
 shell.echo(`Modifying final package.json`);
 const packageJSON = JSON.parse(fs.readFileSync(`./${NPM_DIR}/package.json`));


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](/okta/okta-oidc-middleware/blob/master/CONTRIBUTING.md#commit)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix (**OBVIOUS FIX**)
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Adding Tests
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Users are unable to consume the typescript types found in this package. This is due to the `./scripts/build.js` file not copying the `./types/` directory to `./dist`. Thus when the package is published, the types are missing for downstream consumers. See image below

![image](https://user-images.githubusercontent.com/98292544/233911289-d95045db-68e7-48ef-aca3-f878d726be6a.png)


Issue Number: N/A


## What is the new behavior?

Users are able to consume types.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


## Reviewers

