### PR TITLE
fix: adds types to output bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 5.3.1
+-[#81](https://github.com/okta/okta-oidc-middleware/pull/81) fix: includes types in output bundle (#75 wasn't properly backported)
+
+# 5.3.0
+-[#77](https://github.com/okta/okta-oidc-middleware/pull/77) upgrades openid-client
+
+# 5.2.1
+-[#75](https://github.com/okta/okta-oidc-middleware/pull/75) fix: includes types in output bundle
+
 # 5.2.0
 -[#74](https://github.com/okta/okta-oidc-middleware/pull/74) feat: adds Node 20 support
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@okta/oidc-middleware",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "OpenId Connect middleware for authorization code flows",
   "repository": "https://github.com/okta/okta-oidc-middleware",
   "homepage": "https://github.com/okta/okta-oidc-middleware#readme",


### PR DESCRIPTION
Backport already merged: https://github.com/okta/okta-oidc-middleware/commit/e403085e34261f2ade02b26d7d74d8938c7d38f6