### PR TITLE
fix: keep the issuer path in the OIDC discovery URL

### DIFF
--- a/src/oidcUtil.js
+++ b/src/oidcUtil.js
@@ -61,6 +61,14 @@ function appendOptionsToQuery(url, options) {
   return url;
 }
 
+// A leading slash is origin-relative, so "/.well-known/..." would drop an
+// issuer path such as /oauth2/default. Resolve a relative well-known suffix
+// against a trailing-slash base instead.
+function getDiscoveryUrl(issuer) {
+  const base = issuer.endsWith('/') ? issuer : `${issuer}/`;
+  return new URL('.well-known/openid-configuration', base).href;
+}
+
 oidcUtil.createClient = context => {
   const {
     issuer,
@@ -81,7 +89,7 @@ oidcUtil.createClient = context => {
     return options;
   };
 
-  return Issuer.discover((new URL('/.well-known/openid-configuration', issuer)).href)
+  return Issuer.discover(getDiscoveryUrl(issuer))
   .then((iss) => {
     const client = new iss.Client({
       client_id,

--- a/test/unit/constructor.spec.js
+++ b/test/unit/constructor.spec.js
@@ -202,6 +202,45 @@ describe('new ExpressOIDC()', () => {
     });
   });
 
+  it('should keep a custom authorization server path in the discovery URL', done => {
+    const issuer = 'https://foo.app/oauth2/default';
+    nock('https://foo.app')
+    .get('/oauth2/default/.well-known/openid-configuration')
+    .reply(200, {
+      issuer
+    });
+    new ExpressOIDC({
+      ...minimumConfig,
+      issuer
+    })
+    .on('error', (e) => {
+      done(e);
+    })
+    .on('ready', () => {
+      expect(nock.isDone()).toBe(true);
+      done();
+    });
+  });
+
+  it('should keep a trailing-slash issuer path in the discovery URL', done => {
+    nock('https://foo.app')
+    .get('/oauth2/default/.well-known/openid-configuration')
+    .reply(200, {
+      issuer: 'https://foo.app/oauth2/default'
+    });
+    new ExpressOIDC({
+      ...minimumConfig,
+      issuer: 'https://foo.app/oauth2/default/'
+    })
+    .on('error', (e) => {
+      done(e);
+    })
+    .on('ready', () => {
+      expect(nock.isDone()).toBe(true);
+      done();
+    });
+  });
+
   // eslint-disable-next-line jest/no-test-callback
   it('should throw ETIMEOUT if the timeout is reached', (done) => {
     nock('https://foo.app')


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
- [x] Bugfix

## What is the current behavior?

`Issuer.discover(new URL('/.well-known/openid-configuration', issuer))` treats that path as origin-relative. A custom authorization server such as `https://{yourOktaDomain}/oauth2/default` then requests `/.well-known/openid-configuration` on the org root instead of under `/oauth2/default`.

Issue Number: #110

## What is the new behavior?

Discovery is built from a trailing-slash issuer base plus a relative `.well-known/openid-configuration` suffix, so the issuer path is kept. Org-level issuers still hit `/.well-known/openid-configuration`. Unit tests cover both a path issuer and a trailing slash.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No